### PR TITLE
HTML reporting of plots

### DIFF
--- a/src/caveat/report.py
+++ b/src/caveat/report.py
@@ -80,7 +80,7 @@ def get_html_plot_data(testname, data_dict, axis_dict=None, truncate=False):
                 leading = handle[0]
                 data_proc = next((i for i, v in enumerate(handle) if v != leading), None)
             else:
-                data_proc = 0
+                data_proc = next((i for i, v in enumerate(handle)), None)
             #skip plot, if 'truncated_data' is empty
             if data_proc is None:
                 continue
@@ -93,7 +93,7 @@ def get_html_plot_data(testname, data_dict, axis_dict=None, truncate=False):
             plt.xlabel("Time (ns)")
             plot_data += handle_names[ii]
             plot_data += mpld3.fig_to_html(fig)
-    return plot_data
+        return plot_data
 
 
 def make_report(testname: str, cfg_plot: dict, outfilepath: str='../results/'):


### PR DESCRIPTION
## Scope
- Add HTML reporting of matplotlib-generated plots, e.g. for illustrating signal timeline
- Contributes to https://github.com/ERAS-Research/sanimut_fpga/pull/119