### PR TITLE
'Physical' module regression fix, add author ORCID

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -6,7 +6,7 @@ authors:
   orcid: "https://orcid.org/0000-0001-7536-2215"
 - family-names: "Murray"
   given-names: "Ferris"
-  orcid: 
+  orcid: "https://orcid.org/0009-0007-6601-4359"
 - family-names: "Trottier"
   given-names: "Philippe"
   orcid: 

--- a/src/caveat/physical/adder.py
+++ b/src/caveat/physical/adder.py
@@ -5,7 +5,7 @@ import cocotb
 from cocotb.queue import Queue
 import numpy as np
 
-from caveat.simulation import PhysicalSimulation
+from .simulation import PhysicalSimulation
 
 
 class Adder(PhysicalSimulation):

--- a/src/caveat/physical/attenuator.py
+++ b/src/caveat/physical/attenuator.py
@@ -5,7 +5,7 @@ import cocotb
 from cocotb.queue import Queue
 import math
 
-from caveat.simulation import PhysicalSimulation
+from .simulation import PhysicalSimulation
 
 
 class Attenuator(PhysicalSimulation):

--- a/src/caveat/physical/delayline.py
+++ b/src/caveat/physical/delayline.py
@@ -5,7 +5,7 @@ import cocotb
 from cocotb.queue import Queue
 import math
 
-from caveat.simulation import PhysicalSimulation
+from .simulation import PhysicalSimulation
 
 
 class DelayLine(PhysicalSimulation):

--- a/src/caveat/physical/loopback.py
+++ b/src/caveat/physical/loopback.py
@@ -4,7 +4,7 @@
 import cocotb
 from cocotb.queue import Queue
 
-from caveat.simulation import PhysicalSimulation
+from .simulation import PhysicalSimulation
 
 
 class Loopback(PhysicalSimulation):


### PR DESCRIPTION
Internal testing revealed the imports in the physical folder were incorrect. updating relative paths and reinstalling led to tests passing.

Also added ORCID ID to citation file