### PR TITLE
Add option to force waiting in send_message

### DIFF
--- a/src/caveat/caveatbench.py
+++ b/src/caveat/caveatbench.py
@@ -154,10 +154,14 @@ class CaveatBench():
         if monitor:
             self.monitors[label] = CaveatAxiStreamMonitor(bus, clk)
 
-    async def send_message(self, sender_name, message):
+    async def send_message(self, sender_name, message, force_wait=False):
         """Send an integer, a list of integers, a byte, or a bytearray to DUT.
         """
-        self.sources[sender_name].send_nowait(list(message))
+        if force_wait:
+            await self.sources[sender_name].send(list(message))
+            await self.sources[sender_name].wait()
+        else:
+            self.sources[sender_name].send_nowait(list(message))
 
     async def read_message(self, receiver_name):
         """Read value out from specified receiver, returns list of integers


### PR DESCRIPTION
adds a keyword argument to the send_message function. Development saw the no_wait option of sending data become the default, however adding back in functionality to force timing may help in some applications